### PR TITLE
Enable editing all consultant details on About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -87,34 +87,37 @@
                 <!-- Team Member 1 -->
                 <div class="bg-gray-50 rounded-xl overflow-hidden shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 text-center">
                     <div class="pt-8 px-6">
-                         <img id="consultant1-photo" class="lazyload w-32 h-32 rounded-full mx-auto object-cover border-4 border-secondary shadow-md" data-src="https://images.unsplash.com/photo-1560250097-0b93528c311a?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=200&h=200&q=80" alt="المستشار أحمد خالد">
+                         <img id="consultant1-photo" class="lazyload w-32 h-32 rounded-full mx-auto object-cover border-4 border-secondary shadow-md" data-src="https://images.unsplash.com/photo-1560250097-0b93528c311a?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=200&h=200&q=80" alt="المستشار الأول">
                     </div>
                     <div class="p-6">
-                        <h3 class="text-2xl font-semibold mb-2 text-gray-800">أحمد خالد</h3>
-                        <p class="text-primary font-medium mb-3">مستشار تخصصات هندسية</p>
-                        <p class="text-gray-600 text-sm leading-relaxed">خبرة 5 سنوات في توجيه الطلاب لاختيار التخصصات الهندسية والعلمية المناسبة لميولهم وقدراتهم.</p>
+                        <h3 id="consultant1-name" class="text-2xl font-semibold mb-2 text-gray-800">أحمد خالد</h3>
+                        <p id="consultant1-title" class="text-primary font-medium mb-3">مستشار تخصصات هندسية</p>
+                        <p id="consultant1-description" class="text-gray-600 text-sm leading-relaxed">خبرة 5 سنوات في توجيه الطلاب لاختيار التخصصات الهندسية والعلمية المناسبة لميولهم وقدراتهم.</p>
+                        <a id="consultant1-cv" href="#" class="text-primary font-medium mt-3 inline-block">السيرة الذاتية</a>
                     </div>
                 </div>
                 <!-- Team Member 2 -->
                 <div class="bg-gray-50 rounded-xl overflow-hidden shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 text-center">
                     <div class="pt-8 px-6">
-                        <img id="consultant2-photo" class="lazyload w-32 h-32 rounded-full mx-auto object-cover border-4 border-secondary shadow-md" data-src="https://images.unsplash.com/photo-1573496359142-b8d87734a5a2?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=200&h=200&q=80" alt="المستشارة سارة المالكي">
+                        <img id="consultant2-photo" class="lazyload w-32 h-32 rounded-full mx-auto object-cover border-4 border-secondary shadow-md" data-src="https://images.unsplash.com/photo-1573496359142-b8d87734a5a2?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=200&h=200&q=80" alt="المستشار الثاني">
                     </div>
                     <div class="p-6">
-                        <h3 class="text-2xl font-semibold mb-2 text-gray-800">سارة المالكي</h3>
-                        <p class="text-primary font-medium mb-3">مستشارة تخصصات أدبية وإنسانية</p>
-                        <p class="text-gray-600 text-sm leading-relaxed">خبيرة في توجيه الطلاب لاختيار التخصصات المناسبة في المجالات الأدبية والإنسانية، ومساعدتهم على اكتشاف شغفهم.</p>
+                        <h3 id="consultant2-name" class="text-2xl font-semibold mb-2 text-gray-800">سارة المالكي</h3>
+                        <p id="consultant2-title" class="text-primary font-medium mb-3">مستشارة تخصصات أدبية وإنسانية</p>
+                        <p id="consultant2-description" class="text-gray-600 text-sm leading-relaxed">خبيرة في توجيه الطلاب لاختيار التخصصات المناسبة في المجالات الأدبية والإنسانية، ومساعدتهم على اكتشاف شغفهم.</p>
+                        <a id="consultant2-cv" href="#" class="text-primary font-medium mt-3 inline-block">السيرة الذاتية</a>
                     </div>
                 </div>
                 <!-- Team Member 3 -->
                 <div class="bg-gray-50 rounded-xl overflow-hidden shadow-lg hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 text-center">
                      <div class="pt-8 px-6">
-                        <img id="consultant3-photo" class="lazyload w-32 h-32 rounded-full mx-auto object-cover border-4 border-secondary shadow-md" data-src="https://images.unsplash.com/photo-1599566150163-29194dcaad36?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=200&h=200&q=80" alt="المستشار محمد الجابري">
+                        <img id="consultant3-photo" class="lazyload w-32 h-32 rounded-full mx-auto object-cover border-4 border-secondary shadow-md" data-src="https://images.unsplash.com/photo-1599566150163-29194dcaad36?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=200&h=200&q=80" alt="المستشار الثالث">
                     </div>
                     <div class="p-6">
-                        <h3 class="text-2xl font-semibold mb-2 text-gray-800">محمد الجابري</h3>
-                        <p class="text-primary font-medium mb-3">مستشار تطوير مهارات</p>
-                        <p class="text-gray-600 text-sm leading-relaxed">متخصص في تطوير المهارات الدراسية وتقنيات التعلم الفعال، مع خبرة في مساعدة الطلاب على تحسين أدائهم الأكاديمي.</p>
+                        <h3 id="consultant3-name" class="text-2xl font-semibold mb-2 text-gray-800">محمد الجابري</h3>
+                        <p id="consultant3-title" class="text-primary font-medium mb-3">مستشار تطوير مهارات</p>
+                        <p id="consultant3-description" class="text-gray-600 text-sm leading-relaxed">متخصص في تطوير المهارات الدراسية وتقنيات التعلم الفعال، مع خبرة في مساعدة الطلاب على تحسين أدائهم الأكاديمي.</p>
+                        <a id="consultant3-cv" href="#" class="text-primary font-medium mt-3 inline-block">السيرة الذاتية</a>
                     </div>
                 </div>
             </div>
@@ -306,10 +309,19 @@
     <script>
 const c = window.siteContent;
 document.getElementById("about-hero-text").innerText = c.aboutHeroText;
-function upd(id, url){var el=document.getElementById(id); el.setAttribute("data-src", url); el.src=url;}
-upd("consultant1-photo", c.consultants[0].photo);
-upd("consultant2-photo", c.consultants[1].photo);
-upd("consultant3-photo", c.consultants[2].photo);
+function updateConsultant(i){
+    const cons = c.consultants[i];
+    const idx = i + 1;
+    const photo = document.getElementById(`consultant${idx}-photo`);
+    photo.setAttribute("data-src", cons.photo);
+    photo.src = cons.photo;
+    photo.alt = cons.name;
+    document.getElementById(`consultant${idx}-name`).innerText = cons.name;
+    document.getElementById(`consultant${idx}-title`).innerText = cons.title;
+    document.getElementById(`consultant${idx}-description`).innerText = cons.description;
+    document.getElementById(`consultant${idx}-cv`).href = cons.cv;
+}
+for(let i=0;i<c.consultants.length;i++){ updateConsultant(i); }
 </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lazysizes/5.3.2/lazysizes.min.js" async=""></script>
 </body>

--- a/admin/index.html
+++ b/admin/index.html
@@ -78,17 +78,44 @@
                         <label for="about-hero-text-input" class="block mb-1">نص صفحة عنّا</label>
                         <textarea id="about-hero-text-input" class="w-full border p-2 rounded"></textarea>
                     </div>
-                    <div>
-                        <label for="consultant1-photo-input" class="block mb-1">رابط صورة المستشار 1</label>
+                    <div class="border rounded p-4 space-y-2">
+                        <h3 class="font-semibold mb-2">المستشار 1</h3>
+                        <label for="consultant1-name-input" class="block mb-1">الاسم</label>
+                        <input id="consultant1-name-input" type="text" class="w-full border p-2 rounded">
+                        <label for="consultant1-title-input" class="block mt-2 mb-1">المسمى الوظيفي</label>
+                        <input id="consultant1-title-input" type="text" class="w-full border p-2 rounded">
+                        <label for="consultant1-desc-input" class="block mt-2 mb-1">الوصف</label>
+                        <textarea id="consultant1-desc-input" class="w-full border p-2 rounded"></textarea>
+                        <label for="consultant1-photo-input" class="block mt-2 mb-1">رابط الصورة</label>
                         <input id="consultant1-photo-input" type="text" class="w-full border p-2 rounded">
+                        <label for="consultant1-cv-input" class="block mt-2 mb-1">رابط السيرة الذاتية</label>
+                        <input id="consultant1-cv-input" type="text" class="w-full border p-2 rounded">
                     </div>
-                    <div>
-                        <label for="consultant2-photo-input" class="block mb-1">رابط صورة المستشار 2</label>
+                    <div class="border rounded p-4 space-y-2">
+                        <h3 class="font-semibold mb-2">المستشار 2</h3>
+                        <label for="consultant2-name-input" class="block mb-1">الاسم</label>
+                        <input id="consultant2-name-input" type="text" class="w-full border p-2 rounded">
+                        <label for="consultant2-title-input" class="block mt-2 mb-1">المسمى الوظيفي</label>
+                        <input id="consultant2-title-input" type="text" class="w-full border p-2 rounded">
+                        <label for="consultant2-desc-input" class="block mt-2 mb-1">الوصف</label>
+                        <textarea id="consultant2-desc-input" class="w-full border p-2 rounded"></textarea>
+                        <label for="consultant2-photo-input" class="block mt-2 mb-1">رابط الصورة</label>
                         <input id="consultant2-photo-input" type="text" class="w-full border p-2 rounded">
+                        <label for="consultant2-cv-input" class="block mt-2 mb-1">رابط السيرة الذاتية</label>
+                        <input id="consultant2-cv-input" type="text" class="w-full border p-2 rounded">
                     </div>
-                    <div>
-                        <label for="consultant3-photo-input" class="block mb-1">رابط صورة المستشار 3</label>
+                    <div class="border rounded p-4 space-y-2">
+                        <h3 class="font-semibold mb-2">المستشار 3</h3>
+                        <label for="consultant3-name-input" class="block mb-1">الاسم</label>
+                        <input id="consultant3-name-input" type="text" class="w-full border p-2 rounded">
+                        <label for="consultant3-title-input" class="block mt-2 mb-1">المسمى الوظيفي</label>
+                        <input id="consultant3-title-input" type="text" class="w-full border p-2 rounded">
+                        <label for="consultant3-desc-input" class="block mt-2 mb-1">الوصف</label>
+                        <textarea id="consultant3-desc-input" class="w-full border p-2 rounded"></textarea>
+                        <label for="consultant3-photo-input" class="block mt-2 mb-1">رابط الصورة</label>
                         <input id="consultant3-photo-input" type="text" class="w-full border p-2 rounded">
+                        <label for="consultant3-cv-input" class="block mt-2 mb-1">رابط السيرة الذاتية</label>
+                        <input id="consultant3-cv-input" type="text" class="w-full border p-2 rounded">
                     </div>
                 </div>
             </div>
@@ -115,9 +142,21 @@
             document.getElementById('service3-title-input').value = c.featuredServices[2].title;
             document.getElementById('service3-desc-input').value = c.featuredServices[2].description;
             document.getElementById('about-hero-text-input').value = c.aboutHeroText;
+            document.getElementById('consultant1-name-input').value = c.consultants[0].name;
+            document.getElementById('consultant1-title-input').value = c.consultants[0].title;
+            document.getElementById('consultant1-desc-input').value = c.consultants[0].description;
             document.getElementById('consultant1-photo-input').value = c.consultants[0].photo;
+            document.getElementById('consultant1-cv-input').value = c.consultants[0].cv;
+            document.getElementById('consultant2-name-input').value = c.consultants[1].name;
+            document.getElementById('consultant2-title-input').value = c.consultants[1].title;
+            document.getElementById('consultant2-desc-input').value = c.consultants[1].description;
             document.getElementById('consultant2-photo-input').value = c.consultants[1].photo;
+            document.getElementById('consultant2-cv-input').value = c.consultants[1].cv;
+            document.getElementById('consultant3-name-input').value = c.consultants[2].name;
+            document.getElementById('consultant3-title-input').value = c.consultants[2].title;
+            document.getElementById('consultant3-desc-input').value = c.consultants[2].description;
             document.getElementById('consultant3-photo-input').value = c.consultants[2].photo;
+            document.getElementById('consultant3-cv-input').value = c.consultants[2].cv;
         }
 
         function showDashboard() {
@@ -154,9 +193,21 @@
             c.featuredServices[2].title = document.getElementById('service3-title-input').value;
             c.featuredServices[2].description = document.getElementById('service3-desc-input').value;
             c.aboutHeroText = document.getElementById('about-hero-text-input').value;
+            c.consultants[0].name = document.getElementById('consultant1-name-input').value;
+            c.consultants[0].title = document.getElementById('consultant1-title-input').value;
+            c.consultants[0].description = document.getElementById('consultant1-desc-input').value;
             c.consultants[0].photo = document.getElementById('consultant1-photo-input').value;
+            c.consultants[0].cv = document.getElementById('consultant1-cv-input').value;
+            c.consultants[1].name = document.getElementById('consultant2-name-input').value;
+            c.consultants[1].title = document.getElementById('consultant2-title-input').value;
+            c.consultants[1].description = document.getElementById('consultant2-desc-input').value;
             c.consultants[1].photo = document.getElementById('consultant2-photo-input').value;
+            c.consultants[1].cv = document.getElementById('consultant2-cv-input').value;
+            c.consultants[2].name = document.getElementById('consultant3-name-input').value;
+            c.consultants[2].title = document.getElementById('consultant3-title-input').value;
+            c.consultants[2].description = document.getElementById('consultant3-desc-input').value;
             c.consultants[2].photo = document.getElementById('consultant3-photo-input').value;
+            c.consultants[2].cv = document.getElementById('consultant3-cv-input').value;
             window.saveSiteContent();
             alert('تم حفظ المحتوى');
         });

--- a/js/content.js
+++ b/js/content.js
@@ -7,16 +7,39 @@
     ],
     aboutHeroText: 'نحن هنا لمساعدتك في رسم ملامح مستقبلك الأكاديمي والمهني بثقة واقتدار.',
     consultants: [
-      { photo: 'https://images.unsplash.com/photo-1560250097-0b93528c311a?ixlib=rb-4.0.3&auto=format&fit=crop&w=200&h=200&q=80' },
-      { photo: 'https://images.unsplash.com/photo-1573496359142-b8d87734a5a2?ixlib=rb-4.0.3&auto=format&fit=crop&w=200&h=200&q=80' },
-      { photo: 'https://images.unsplash.com/photo-1603415526960-f8f1f66216d3?ixlib=rb-4.0.3&auto=format&fit=crop&w=200&h=200&q=80' }
+      {
+        name: 'أحمد خالد',
+        title: 'مستشار تخصصات هندسية',
+        description: 'خبرة 5 سنوات في توجيه الطلاب لاختيار التخصصات الهندسية والعلمية المناسبة لميولهم وقدراتهم.',
+        photo: 'https://images.unsplash.com/photo-1560250097-0b93528c311a?ixlib=rb-4.0.3&auto=format&fit=crop&w=200&h=200&q=80',
+        cv: '#'
+      },
+      {
+        name: 'سارة المالكي',
+        title: 'مستشارة تخصصات أدبية وإنسانية',
+        description: 'خبيرة في توجيه الطلاب لاختيار التخصصات المناسبة في المجالات الأدبية والإنسانية، ومساعدتهم على اكتشاف شغفهم.',
+        photo: 'https://images.unsplash.com/photo-1573496359142-b8d87734a5a2?ixlib=rb-4.0.3&auto=format&fit=crop&w=200&h=200&q=80',
+        cv: '#'
+      },
+      {
+        name: 'محمد الجابري',
+        title: 'مستشار تطوير مهارات',
+        description: 'متخصص في تطوير المهارات الدراسية وتقنيات التعلم الفعال، مع خبرة في مساعدة الطلاب على تحسين أدائهم الأكاديمي.',
+        photo: 'https://images.unsplash.com/photo-1603415526960-f8f1f66216d3?ixlib=rb-4.0.3&auto=format&fit=crop&w=200&h=200&q=80',
+        cv: '#'
+      }
     ]
   };
-  if(!localStorage.getItem('siteContent')){
-    localStorage.setItem('siteContent', JSON.stringify(defaultContent));
-  }
-  window.siteContent = JSON.parse(localStorage.getItem('siteContent'));
+
+  const stored = JSON.parse(localStorage.getItem('siteContent') || 'null');
+  const c = stored || defaultContent;
+  c.consultants = defaultContent.consultants.map(function(def, idx){
+    return Object.assign({}, def, (c.consultants && c.consultants[idx]) || {});
+  });
+
+  window.siteContent = c;
   window.saveSiteContent = function(){
     localStorage.setItem('siteContent', JSON.stringify(window.siteContent));
-  }
+  };
+  window.saveSiteContent();
 })();


### PR DESCRIPTION
## Summary
- Expand site content model to store each consultant's name, title, description, photo and CV link
- Update admin dashboard to edit full consultant profiles and hero text
- Drive About page consultant cards from editable content, including CV links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899b66a52d88329863599c89ba356cf
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added full editing for all consultant details on the About page, including name, title, description, photo, and CV link, through the admin dashboard.

- **New Features**
  - Admins can now edit each consultant’s name, title, description, photo, and CV link.
  - About page consultant cards now show all updated details and CV links.

<!-- End of auto-generated description by cubic. -->

